### PR TITLE
Torch device

### DIFF
--- a/emotions_classifier/EmotionRecognizer.py
+++ b/emotions_classifier/EmotionRecognizer.py
@@ -1,4 +1,5 @@
 from torch import zeros, inference_mode, randint
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from . import RAVDESSDataset
@@ -6,6 +7,15 @@ from . import RAVDESSDataset
 class EmotionRecognizer(nn.Module):
 
     dummy_input = zeros((32,1,64,94), device='cpu')
+
+    @property
+    def model_device(self):
+        try:
+            return next(self.parameters()).device
+        except StopIteration:
+            # Fallback for models with no parameters
+            return torch.device("cpu")
+
     def __init__(self, dropout_prob = 0.4, conv_dropout_prob = 0.3):
         super(EmotionRecognizer, self).__init__()
         self.conv1 = nn.Conv2d(1, 64, kernel_size=3, stride=1, padding=1)

--- a/emotions_classifier/EmotionRecognizer.py
+++ b/emotions_classifier/EmotionRecognizer.py
@@ -57,7 +57,7 @@ class EmotionRecognizer(nn.Module):
         with inference_mode():
             idx = randint(0, len(dataset), (1,)).item()
             mel_spec, label = dataset[idx]
-
+            mel_spec = mel_spec.to(self.model_device)
             mel_spec = mel_spec.unsqueeze(0)
             output = self(mel_spec)
             predicted_class = output.argmax(dim=1).item()

--- a/main.py
+++ b/main.py
@@ -1,13 +1,13 @@
 from emotions_classifier.utils import unzip_nested_dataset, load_ravdess_data, RAVDESS_DOWNLOAD_URL, \
     download_dataset_from_gdrive, load_model_for_inference, split_train_test_val
 from emotions_classifier import RAVDESS_ZIP_PATH, RAVDESS_DATASET_DIR
-
+import torch
 
 MODEL_PATH = "EmotionsClassifier.pth"
 MODEL_URL = "https://drive.google.com/uc?id=1rEBqU3geg2V4_W9QGY-nZGWWdNXd4zrq"
 
 
-def inference():
+def inference(torch_device):
     download_dataset_from_gdrive(RAVDESS_DOWNLOAD_URL, RAVDESS_ZIP_PATH)
     class_names = [
         "Neutral", "Calm", "Happy", "Sad", "Angry", "Fearful", "Disgust", "Surprised"
@@ -17,10 +17,12 @@ def inference():
 
     _, test_dataset, _ = split_train_test_val(file_paths, labels)
 
-    my_model = load_model_for_inference(MODEL_URL, MODEL_PATH)
+    my_model = load_model_for_inference(MODEL_URL, MODEL_PATH, device=torch_device)
     from GUI import MyGUI
     gui = MyGUI()
     gui.show_gui(my_model, test_dataset, class_names)
 
 if __name__ == "__main__":
-    inference()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(5*">"+f"Inference using {device}")
+    inference(device)

--- a/train.py
+++ b/train.py
@@ -50,7 +50,7 @@ def train_and_save_model(model, train_loader: DataLoader, val_loader, epochs=10,
     print(f"Model saved to {MODEL_PATH}")
 
 
-def test_model(model, test_loader: DataLoader):
+def test_model(model: torch.nn.Module, test_loader: DataLoader) -> float:
     """Tests the model on provided DataLoader"""
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model.to(device)
@@ -68,8 +68,9 @@ def test_model(model, test_loader: DataLoader):
             # noinspection PyUnresolvedReferences
             correct += (predicted == labels).sum().item()
 
-    print(f"Test Accuracy: {correct / total * 100:.2f}%, for total of {total} predictions")
-    return model
+    test_accuracy= correct / total
+    print(f"Test Accuracy: {test_accuracy * 100:.2f}%, for total of {total} predictions")
+    return test_accuracy
 
 def train_save_test_model():
     # Download the dataset, if not already downloaded


### PR DESCRIPTION
Add better usage of cuda 

Now both train.py and main.py will always use CUDA if only available. Also changed the model class, so that it's "aware" of its device via a property. Now method make_one_prediction() it automatically casts the data to correct device - user does not have to do anything.